### PR TITLE
Fixed bug when no file/directory is selected

### DIFF
--- a/Ratty/src/de/sogomn/rat/gui/swing/FileBrowserSwingGui.java
+++ b/Ratty/src/de/sogomn/rat/gui/swing/FileBrowserSwingGui.java
@@ -216,9 +216,11 @@ public final class FileBrowserSwingGui extends AbstractSwingGui implements IFile
 	}
 	
 	private void actionPerformed(final ActionEvent a) {
+		if (!fileList.isSelectionEmpty()){
 		final String actionCommand = a.getActionCommand();
 		
 		notifyListeners(controller -> controller.userInput(actionCommand, this));
+		}
 	}
 	
 	private void addFileEntry(final String name, final boolean directory) {


### PR DESCRIPTION
Client would crash and restart if no file/directory was selected and the Jmenu was used